### PR TITLE
Kodi 18 crash fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # plugin.program.autocompletion
 Plugin to provide autocompletion for the virtual keyboard (needs skin support)
 
-Forked from https://github.com/xulek/script.module.autocompletion
+
 
 Resolved crash under Kodi 18.x due to multiple busy dialogs. Tested with youtube and vimeo plugins on Rpi4 (Retropie / Kodi 18.7)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Plugin to provide autocompletion for the virtual keyboard (needs skin support)
 Will be working only with https://github.com/xulek/script.module.autocompletion
 
 The autocompletion is limited to a global/kodi builtin search. With plugins cause Kodi19 application to crash. This is a 99% KODI bug.
+
+Resolved crash under Kodi 18.x on RPI

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # plugin.program.autocompletion
 Plugin to provide autocompletion for the virtual keyboard (needs skin support)
 
-Will be working only with https://github.com/xulek/script.module.autocompletion
+Forked from https://github.com/xulek/script.module.autocompletion
 
-The autocompletion is limited to a global/kodi builtin search. With plugins cause Kodi19 application to crash. This is a 99% KODI bug.
-
-Resolved crash under Kodi 18.x on RPI
+Resolved crash under Kodi 18.x due to multiple busy dialogs. Tested with youtube and vimeo plugins on Rpi4 (Retropie / Kodi 18.7)

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.autocompletion" name="AutoCompletion for virtual keyboard" version="1.0.1" provider-name="Philipp Temminghoff (phil65)">
+<addon id="plugin.program.autocompletion" name="AutoCompletion for virtual keyboard" version="1.0.2" provider-name="Philipp Temminghoff (phil65)">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.autocompletion" version="1.0.0"/>

--- a/plugin.py
+++ b/plugin.py
@@ -45,7 +45,7 @@ def pass_list_to_skin(data=[], handle=None, limit=False):
     if data:
         items = create_listitems(data)
         xbmcplugin.addDirectoryItems(handle=handle, items=[(i.getProperty("path"), i, False) for i in items], totalItems=len(items))
-
+    xbmc.executebuiltin('Dialog.Close(busydialog)')  # Fix Kodi 18.x 
     xbmcplugin.endOfDirectory(handle)
 
 


### PR DESCRIPTION
Resolved crash under Kodi 18.x due to multiple busy dialogs. Tested with youtube and vimeo plugins on Rpi4 (Retropie / Kodi 18.7)

Credit to @domb84 

https://github.com/domb84/plugin.program.autocompletion/commit/4f48413546d2b748a22c05957dbfc6ea5c071a3b

https://github.com/phil65/plugin.program.autocompletion/issues/12#issuecomment-683470871